### PR TITLE
Fix: gettattachmentraw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ example/CsharpExample/src/.vs
 example/CsharpExample/src/CsharpExample/bin
 example/CsharpExample/src/CsharpExample/obj
 example/CsharpExample/src/CsharpExample/.vs
+*.user

--- a/src/KeePassCommand/Program.cs
+++ b/src/KeePassCommand/Program.cs
@@ -180,7 +180,7 @@ namespace KeePassCommand
                         throw new Exception("getattachmentraw must query exactly one entry");
 
                     List<ResponseItem> entry = send.Response.Entries[0];
-                    if (entry.Count != 2 || entry[0].Parts[0] != "title")
+                    if (entry.Count != 2 || entry[0].Parts[0].ToLowerInvariant() != "title")
                         throw new Exception("getattachmentraw must query exactly one entry");
 
                     byte[] attachment = Convert.FromBase64String(entry[1].Parts[1]);


### PR DESCRIPTION
When running 
KeepassCommand getattachmentraw -out:"example_attachement.txt" "Sample Entry" "example_attachment.txt"
the resulting attachement says "getattachmentraw must query exactly one entry"

Checking against lowercase fixes the issue

